### PR TITLE
Issue 11: Expose PostgreSQL on a non-standard port.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This will start the database, web hook, and API server.
 
 ## Accessing services running in containers
 
-In order to avoid conflict with other databases running in development, 
+In order to avoid conflict with other databases running in development, PostgreSQL is exposed on port 5550 on the host machine. The webhook and API are running on ports 8079 and 8080 respectively.
 
 To run the snapshot script, navigate to the snapshot subdirectory and execute
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ Once you have docker installed and running, navigate to the root project directo
 
 ```docker-compose up```
 
-This will start the database, web hook, and API server.
+This will start the database, web hook, and API server. 
+
+## Accessing services running in containers
+
+In order to avoid conflict with other databases running in development, 
 
 To run the snapshot script, navigate to the snapshot subdirectory and execute
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
       dockerfile: Dockerfile
     image: db
     ports:
-     - "5432:5432"
+     - "5550:5432"
   webhook:
     build:
       context: ./webhook


### PR DESCRIPTION
Updated the docker compose file to expose PostgreSQL on port 5550 and added documentation to note this.